### PR TITLE
Bump cliss and magcli versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "cliss": "^0.0.9",
+    "cliss": "0.0.9",
     "find-up": "^2.1.0",
     "for-each-property": "0.0.4",
     "inspect-property": "0.0.7"
   },
   "devDependencies": {
-    "mocha": "^4.0.1"
+    "mocha": "^8.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magicli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Automagically generates command-line interfaces (CLI) for any module. Expected options and help sections are created automatically based on parameters names, with support to async. It can be installed globally, in order to *execute* any module, or .js file, via CLI.",
   "main": "lib/magicli.js",
   "bin": "bin/cli.js",
@@ -28,7 +28,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "cliss": "0.0.8",
+    "cliss": "^0.0.9",
     "find-up": "^2.1.0",
     "for-each-property": "0.0.4",
     "inspect-property": "0.0.7"


### PR DESCRIPTION
@DiegoZoracKy I'm attempting to update all your dependencies that rely on cliss, though you have a lot of circular dependencies that make it hard for me to update  them myself using PRs. While we could usually use  the `^` caret to float the versions, this apparently doesn't work for versions below 1.x.x. Do you have a recommendation about  how we should update all of these dependents? 

Direct Dependents of Magcli
-----------------
- split-skip
- data-query
- image-data-uri
- unpack-string
- object-to-arguments (also circular dependency of cliss)
- inspect-parameters-declaration (also circular dependency of cliss)
- inspect-function (also circular dependency of inspect-property)
- stringify-parameters (also circular dependency of inspect-property)
- convert-excel-to-json

Secondary Dependents
-------------------
inspect-property

Dependency flowchart
-------------------------
Note that both cliss and inspect-property are circular dependencies of magcli.
![image](https://user-images.githubusercontent.com/12994749/105658506-6f866880-5e7b-11eb-8fbe-efaa9e65e11b.png)


Possible solutions:

- Enable dependabot on these repositories and merge in its automatic update PRs.
- OR Update packages versions to >=1.0.0 and use `^` to float the dependencies
- OR You go through all the dependencies and simultaneously push out new versions on all the repositories.

Let me know what you think! 